### PR TITLE
Add support for enum property types

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "nodemon": "^2.0.2",
     "prettier": "^1.19.1",
     "ts-jest": "^25.2.1",
+    "ts-node": "^10.9.1",
     "tslint": "^6.1.0",
     "tslint-config-prettier": "^1.18.0",
     "typescript": "^4.0.0-dev.20200717",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,15 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/vriad/tozod"
+    "url": "https://github.com/colinhacks/tozod"
   },
   "author": "Colin McDonnell <colin@vriad.com>",
   "license": "MIT",
   "sideEffects": false,
   "bugs": {
-    "url": "https://github.com/vriad/tozod/issues"
+    "url": "https://github.com/colinhacks/tozod/issues"
   },
-  "homepage": "https://github.com/vriad/tozod",
+  "homepage": "https://github.com/colinhacks/tozod",
   "dependencies": {},
   "scripts": {
     "clean": "rm -rf lib/*",
@@ -40,10 +40,10 @@
     "ts-node": "^10.9.1",
     "tslint": "^6.1.0",
     "tslint-config-prettier": "^1.18.0",
-    "typescript": "^4.0.0-dev.20200717",
-    "zod": "^1.11.8"
+    "typescript": "~4.5.0",
+    "zod": "^3.21.4"
   },
   "peerDependencies": {
-    "zod": "^1.9.1"
+    "zod": "^3.21.4"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,3 @@
 import * as z from 'zod';
 
-type Schema<T> = z.ZodObject<{ [K in keyof T]: z.ZodType<T[K], any> }> & z.ZodSchema<T>;
-type Effects<T> = z.ZodEffects<Schema<T>>;
-
-export type toZod<T> = Schema<T> | Effects<T>;
+export type toZod<T> = z.ZodObject<{ [K in keyof T]: z.ZodType<T[K], any> }> & z.ZodSchema<T>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,3 @@
 import * as z from 'zod';
 
-type Matches<T> = {
-  [K in keyof T]: z.ZodType<T[K], any>
-};
-
-type ZodMatches<T> = z.ZodObject<Matches<T>> & z.ZodSchema<T>;
-
-export type toZod<T> = ZodMatches<T>;
+export type toZod<T> = z.ZodObject<{ [K in keyof T]: z.ZodType<T[K], any> }> & z.ZodSchema<T>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 import * as z from 'zod';
 
-export type toZod<T> = z.ZodObject<{ [K in keyof T]: z.ZodType<T[K], any> }> & z.ZodSchema<T>;
+type Schema<T> = z.ZodObject<{ [K in keyof T]: z.ZodType<T[K], any> }> & z.ZodSchema<T>;
+type Effects<T> = z.ZodEffects<Schema<T>>;
+
+export type toZod<T> = Schema<T> | Effects<T>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,42 +1,9 @@
 import * as z from 'zod';
 
-type isAny<T> = [any extends T ? 'true' : 'false'] extends ['true'] ? true : false;
-type nonoptional<T> = T extends undefined ? never : T;
-type nonnullable<T> = T extends null ? never : T;
-type equals<X, Y> = [X] extends [Y] ? ([Y] extends [X] ? true : false) : false;
+type Matches<T> = {
+  [K in keyof T]: z.ZodType<T[K], any>
+};
 
-export type toZod<T> = {
-  any: never;
-  optional: z.ZodUnion<[toZod<nonoptional<T>>, z.ZodUndefined]>;
-  nullable: z.ZodUnion<[toZod<nonnullable<T>>, z.ZodNull]>;
-  array: T extends Array<infer U> ? z.ZodArray<toZod<U>> : never;
-  string: z.ZodString;
-  bigint: z.ZodBigInt;
-  number: z.ZodNumber;
-  boolean: z.ZodBoolean;
-  date: z.ZodDate;
-  object: z.ZodObject<{ [k in keyof T]: toZod<T[k]> }, { strict: true }, T>;
-  rest: never;
-}[zodKey<T>];
+type ZodMatches<T> = z.ZodObject<Matches<T>> & z.ZodSchema<T>;
 
-type zodKey<T> = isAny<T> extends true
-  ? 'any'
-  : equals<T, boolean> extends true //[T] extends [booleanUtil.Type]
-  ? 'boolean'
-  : [undefined] extends [T]
-  ? 'optional'
-  : [null] extends [T]
-  ? 'nullable'
-  : T extends any[]
-  ? 'array'
-  : equals<T, string> extends true
-  ? 'string'
-  : equals<T, bigint> extends true //[T] extends [bigintUtil.Type]
-  ? 'bigint'
-  : equals<T, number> extends true //[T] extends [numberUtil.Type]
-  ? 'number'
-  : equals<T, Date> extends true //[T] extends [dateUtil.Type]
-  ? 'date'
-  : T extends { [k: string]: any } //[T] extends [structUtil.Type]
-  ? 'object'
-  : 'rest';
+export type toZod<T> = ZodMatches<T>;

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,6 +1,18 @@
 import * as z from 'zod';
 import { toZod } from '.';
 
+type Player = {
+  name: string;
+  age?: number | undefined;
+  active: boolean | null;
+};
+
+export const Player: toZod<Player> = z.object({
+  name: z.string(),
+  age: z.number().optional(),
+  active: z.boolean().nullable(),
+});
+
 // native enum
 enum UserType {
   Admin = 'admin',

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -5,12 +5,20 @@ type Player = {
   name: string;
   age?: number | undefined;
   active: boolean | null;
+  type: PlayerType;
 };
+
+// test mixed number and string enum
+enum PlayerType {
+  Attacker,
+  Defender = 'Defender'
+}
 
 export const Player: toZod<Player> = z.object({
   name: z.string(),
   age: z.number().optional(),
   active: z.boolean().nullable(),
+  type: z.nativeEnum(PlayerType),
 });
 
 type User = {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -49,8 +49,8 @@ const User: toZod<User> = z.late.object(() => ({
   status: StatusType,
 }));
 
-const Post: toZod<Post> = z.object({
+const Post: toZod<Post> = z.late.object(() => ({
   content: z.string(),
   author: User,
-});
+}));
 

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,4 +1,4 @@
-import * as z from 'zod';
+import z from 'zod';
 import { toZod } from '.';
 
 type Player = {

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,31 +1,18 @@
 import * as z from 'zod';
 import { toZod } from '.';
 
-type Player = {
-  name: string;
-  age?: number | undefined;
-  active: boolean | null;
-  type: PlayerType;
-};
-
-// test mixed number and string enum
-enum PlayerType {
-  Attacker,
-  Defender = 'Defender'
+enum UserType {
+  Guest = 'guest',
+  Standard = 'standard',
+  Admin = 'admin'
 }
-
-export const Player: toZod<Player> = z.object({
-  name: z.string(),
-  age: z.number().optional(),
-  active: z.boolean().nullable(),
-  type: z.nativeEnum(PlayerType),
-});
 
 type User = {
   name: string;
   age?: number | undefined;
   active: boolean | null;
   posts: Post[];
+  type: UserType;
 };
 
 type Post = {
@@ -41,8 +28,8 @@ const User: toZod<User> = z.late.object(() => ({
     .refine(() => false, 'asdf'),
   age: z.number().optional(),
   active: z.boolean().nullable(),
-
   posts: z.array(Post),
+  type: z.nativeEnum(UserType)
 }));
 
 const Post: toZod<Post> = z.late.object(() => ({
@@ -50,4 +37,3 @@ const Post: toZod<Post> = z.late.object(() => ({
   author: User,
 }));
 
-console.log(User.shape.posts.element.shape.author);

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -3,9 +3,8 @@ import { toZod } from '.';
 
 // native enum
 enum UserType {
-  Guest = 'guest',
-  Standard = 'standard',
-  Admin = 0
+  Admin = 'admin',
+  Standard = 'standard'
 }
 
 // zod enum

--- a/src/playground.ts
+++ b/src/playground.ts
@@ -1,11 +1,15 @@
 import * as z from 'zod';
 import { toZod } from '.';
 
+// native enum
 enum UserType {
   Guest = 'guest',
   Standard = 'standard',
-  Admin = 'admin'
+  Admin = 0
 }
+
+// zod enum
+const StatusType = z.enum(['active', 'inactive', 'pending']);
 
 type User = {
   name: string;
@@ -13,6 +17,7 @@ type User = {
   active: boolean | null;
   posts: Post[];
   type: UserType;
+  status: z.infer<typeof StatusType>;
 };
 
 type Post = {
@@ -29,11 +34,12 @@ const User: toZod<User> = z.late.object(() => ({
   age: z.number().optional(),
   active: z.boolean().nullable(),
   posts: z.array(Post),
-  type: z.nativeEnum(UserType)
+  type: z.nativeEnum(UserType),
+  status: StatusType,
 }));
 
-const Post: toZod<Post> = z.late.object(() => ({
+const Post: toZod<Post> = z.object({
   content: z.string(),
   author: User,
-}));
+});
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3779,10 +3779,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.0.0-dev.20200717:
-  version "4.0.0-dev.20200717"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.0-dev.20200717.tgz#4e1100e789cde64fd10cddcf4172f61d6f769a00"
-  integrity sha512-26ECH/H022vF69DJpbpLygzrQ0jI2UTHU59Tnb4mv78yQ2wzNNlLOJdxfEMRoefp0Hx4yA3f9100rn0g7d1OWA==
+typescript@~4.5.0:
+  version "4.5.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
+  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
 
 undefsafe@^2.0.2:
   version "2.0.3"
@@ -4080,7 +4080,7 @@ yn@3.1.1:
   resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
-zod@^1.11.8:
-  version "1.11.8"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-1.11.8.tgz#5e6b2eb3114c73d5043889fa9dfbab0b60a93ff6"
-  integrity sha512-iusmIB00ll0Fxzyhrp8EJPaJDTSyQMKMCwk2hH2XrtgY/QcygPJTX13fSof/r7b4hL5cBeN5aeVl6WN1xpr90g==
+zod@^3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.21.4.tgz#10882231d992519f0a10b5dd58a38c9dabbb64db"
+  integrity sha512-m46AKbrzKVzOzs/DZgVnG5H55N1sv1M8qZU3A8RIKbs3mrACDNeIOeilDymVb2HdmP8uwshOCF4uJ8uM9rCqJw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -151,6 +151,13 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz#10602de5570baea82f8afbfa2630b24e7a8cfe5b"
@@ -325,12 +332,50 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
+  integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.14"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
+  integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
   integrity sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==
   dependencies:
     type-detect "4.0.8"
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
 "@types/babel__core@^7.1.0":
   version "7.1.6"
@@ -438,6 +483,11 @@ acorn-walk@^6.0.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
   integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
 acorn@^6.0.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
@@ -447,6 +497,11 @@ acorn@^7.1.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
   integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
+
+acorn@^8.4.1:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
+  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
 
 ajv@^6.5.5:
   version "6.12.0"
@@ -517,6 +572,11 @@ anymatch@^3.0.3, anymatch@~3.1.1:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -954,6 +1014,11 @@ create-error-class@^3.0.0:
   integrity sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=
   dependencies:
     capture-stack-trace "^1.0.0"
+
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
 cross-spawn@^5.0.1:
   version "5.1.0"
@@ -2494,7 +2559,7 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -3623,6 +3688,25 @@ ts-jest@^25.2.1:
     semver "^5.5"
     yargs-parser "^16.1.0"
 
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tslib@^1.10.0, tslib@^1.8.1:
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
@@ -3791,6 +3875,11 @@ uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-to-istanbul@^4.0.1:
   version "4.1.2"
@@ -3985,6 +4074,11 @@ yargs@^15.0.0:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^18.1.0"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 zod@^1.11.8:
   version "1.11.8"


### PR DESCRIPTION
Hello, I have encouraged our team to use zod at work and it's great! Kudos and thanks for a terrific library.

`toZod` has been very handy in our project but the current implementation isn't capable of checking that an enum property on a zod schema corresponds to that property/type on the target TS type. I tried adding `enum` and `nativeEnum` to the existing ternary implementation but it wasn't working.

Eventually, (radical candor) I turned to ChatGPT-4, described the scenario, and asked it for a utility type that would support enum properties as well. I was surprised by the brevity of the result but it seems to support every scenario in `playground.ts` and who doesn't like a nice concise implementation? 🙂

This should address: https://github.com/colinhacks/tozod/issues/6